### PR TITLE
Fixed Distorted Thumbnails #1

### DIFF
--- a/src/lib/components/BookUI.svelte
+++ b/src/lib/components/BookUI.svelte
@@ -50,7 +50,7 @@
 			class="h-[full] w-full object-cover"
 		/> -->
 		<img
-			class=" h-[300px] w-full rounded-xl"
+			class=" h-[300px] w-full rounded-xl object-cover"
 			src={`${API_SERVER_URL}/proxy?url=${book.thumbUrl}`}
 			alt=""
 		/>


### PR DESCRIPTION
Small fix for Issue #1

Changes:
- added the `object-cover` class to preserve the aspect ratio of the original image as the replaced image while fitting in the content box.